### PR TITLE
bump deps

### DIFF
--- a/grpc-web-client/Cargo.toml
+++ b/grpc-web-client/Cargo.toml
@@ -14,23 +14,23 @@ categories = ["web-programming", "network-programming", "asynchronous"]
 keywords = ["grpc", "tonic", "wasm", "wasm-bindgen", "js"]
 
 [dependencies]
-tonic = { version = "0.4.3", default-features = false }
-prost = { version = "0.7.0", default-features = false }
-http = { version = "0.2.4", default-features = false }
-http-body = { version = "0.4.1", default-features = false }
-bytes = { version = "1.0.1", default-features = false }
-byteorder = { version = "1.4.3", default-features = false }
-base64 = { version = "0.13.0", default-features = false }
-wasm-bindgen = { version = "0.2.73", default-features = false, features = ["serde-serialize"] }
-wasm-bindgen-futures = { version = "0.4.23", default-features = false }
-wasm-streams = { version = "0.1.2" }
-futures = { version = "0.3.13", default-features = false, features = ["alloc"] }
-js-sys = { version = "0.3.50", default-features = false }
-httparse = { version = "1.4.0", default-features = false }
-hyper = { version = "0.14.7", default-features = false }
+tonic = { version = "0.5", default-features = false }
+prost = { version = "0.8", default-features = false }
+http = { version = "0.2", default-features = false }
+http-body = { version = "0.4", default-features = false }
+bytes = { version = "1", default-features = false }
+byteorder = { version = "1", default-features = false }
+base64 = { version = "0.13", default-features = false }
+wasm-bindgen = { version = "0.2", default-features = false, features = ["serde-serialize"] }
+wasm-bindgen-futures = { version = "0.4", default-features = false }
+wasm-streams = { version = "0.1" }
+futures = { version = "0.3", default-features = false, features = ["alloc"] }
+js-sys = { version = "0.3", default-features = false }
+httparse = { version = "1", default-features = false }
+hyper = { version = "0.14", default-features = false }
 
 [dependencies.web-sys]
-version = "0.3.50"
+version = "0.3"
 default-features = false
 features = [
     "Headers",
@@ -44,6 +44,6 @@ features = [
 ]
 
 [dependencies.getrandom]
-version = "0.2.2"
+version = "0.2"
 default-features = false
 features = ["js"]

--- a/test/test-client/Cargo.toml
+++ b/test/test-client/Cargo.toml
@@ -8,15 +8,15 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
-wasm-bindgen = { version = "0.2.73", default-features = false, features = ["serde-serialize"] }
-tonic = { version = "0.4.3", default-features = false, features = ["codegen", "prost"] }
+wasm-bindgen = { version = "0.2", default-features = false, features = ["serde-serialize"] }
+tonic = { version = "0.5", default-features = false, features = ["codegen", "prost"] }
 grpc-web-client = { path = "../../grpc-web-client" }
-prost = { version = "0.7.0", default-features = false }
-wasm-bindgen-test = { version = "0.3.23", default-features = false }
-js-sys = { version = "0.3.50", default-features = false }
+prost = { version = "0.8", default-features = false }
+wasm-bindgen-test = { version = "0.3", default-features = false }
+js-sys = { version = "0.3", default-features = false }
 
 [build-dependencies]
-tonic-build = { version = "0.4.2", default-features = false, features = ["prost"] }
+tonic-build = { version = "0.5", default-features = false, features = ["prost"] }
 
 [profile.release]
 lto = true

--- a/test/test-server/Cargo.toml
+++ b/test/test-server/Cargo.toml
@@ -5,14 +5,14 @@ edition = "2018"
 publish = false
 
 [dependencies]
-tokio = { version = "1.4.0", features = ["full"] }
-tokio-stream = { version = "0.1.5" }
-futures = { version = "0.3.13" }
-prost = "0.7.0"
-pretty_env_logger = "0.4.0"
+tokio = { version = "1", features = ["full"] }
+tokio-stream = { version = "0.1" }
+futures = { version = "0.3" }
+prost = "0.8"
+pretty_env_logger = "0.4"
 
-tonic = { git = "https://github.com/alce/tonic", branch = "grpc-web" }
-tonic-web = { git = "https://github.com/alce/tonic", branch = "grpc-web" }
+tonic = "0.5"
+tonic-web = "0.1"
 
 [build-dependencies]
-tonic-build = { git = "https://github.com/alce/tonic", branch = "grpc-web", features = ["prost"] }
+tonic-build = "0.5"


### PR DESCRIPTION
Allow for current tonic to be used with grpc-web-client.

Also, drop the patch versions of the toml, there is theoratically no need for that. If you really want to stick to a specific version, it's better to commit `Cargo.lock` (as it will also lock the git commit).

Closes: #1