### PR TITLE
Client::new takes Uri

### DIFF
--- a/test/test-client/src/lib.rs
+++ b/test/test-client/src/lib.rs
@@ -1,3 +1,5 @@
+use std::convert::TryInto;
+
 tonic::include_proto!("helloworld");
 tonic::include_proto!("grpc.examples.echo");
 
@@ -9,7 +11,8 @@ use wasm_bindgen_test::*;
 
 #[wasm_bindgen_test]
 async fn hello_world() {
-    let client = Client::new("http://127.0.0.1:8080".to_string());
+    let uri = "http://127.0.0.1:8080".try_into().expect("to be valid Uri");
+    let client = Client::new(&uri).expect("to create Client");
     let mut client = greeter_client::GreeterClient::new(client);
 
     let request = tonic::Request::new(HelloRequest {
@@ -22,7 +25,8 @@ async fn hello_world() {
 
 #[wasm_bindgen_test]
 async fn echo_unary() {
-    let client = Client::new("http://127.0.0.1:8080".to_string());
+    let uri = "http://127.0.0.1:8080".try_into().expect("to be valid Uri");
+    let client = Client::new(&uri).expect("to create Client");
     let mut client = echo_client::EchoClient::new(client);
 
     let request = tonic::Request::new(EchoRequest {
@@ -35,7 +39,8 @@ async fn echo_unary() {
 
 #[wasm_bindgen_test]
 async fn echo_server_stream() {
-    let client = Client::new("http://127.0.0.1:8080".to_string());
+    let uri = "http://127.0.0.1:8080".try_into().expect("to be valid Uri");
+    let client = Client::new(&uri).expect("to create Client");
     let mut client = echo_client::EchoClient::new(client);
 
     let request = tonic::Request::new(EchoRequest {


### PR DESCRIPTION
`Client::new` uses a string for now, allowing the client to be build with an invalid base URI. Using directly `http::Uri` ensure that it is valid (ie having a scheme, authority and no query), returning an error if need be. I also added some asserts in `request`, assuming it only receives a path-and-query URI.

This is an semver breaking change.

WDYT?